### PR TITLE
feat: query for route right after subscription to prevent pending state

### DIFF
--- a/directions/index.js
+++ b/directions/index.js
@@ -1,7 +1,7 @@
 import { createClient, createRequest, defaultExchanges, subscriptionExchange } from '@urql/core';
 import { pipe, subscribe } from 'wonka';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
-import { createRoute, routeUpdate } from './queries.js';
+import { createRoute, routeUpdate, queryRoute } from './queries.js';
 import { drawRoute } from './map.js';
 import * as mapboxPolyline from '@mapbox/polyline';
 import { getDurationString } from '../utils';
@@ -71,6 +71,22 @@ client
         }
       }),
     );
+
+    // Query for the route once to check if the route is computed before the subscription was setup.
+    // In this case we use the response from the query and unsubscribe from the route.
+    // For more informations about routes: https://docs.chargetrip.com/#routes
+    client
+      .query(queryRoute, { id: routeId })
+      .toPromise()
+      .then(response => {
+        const { status, route } = response.data.route;
+        if (status === 'done' && route) {
+          console.log({ route });
+          unsubscribe();
+          drawRoutePolyline(route);
+          displayRouteData(route);
+        }
+      });
   })
   .catch(error => console.log(error));
 

--- a/directions/index.js
+++ b/directions/index.js
@@ -81,7 +81,6 @@ client
       .then(response => {
         const { status, route } = response.data.route;
         if (status === 'done' && route) {
-          console.log({ route });
           unsubscribe();
           drawRoutePolyline(route);
           displayRouteData(route);

--- a/directions/queries.js
+++ b/directions/queries.js
@@ -49,6 +49,46 @@ mutation newRoute{
   }
 `;
 
+export const queryRoute = qql`
+query getRoute($id: ID!) {
+  route(id: $id) {
+    route {
+      charges
+      saving {
+        money
+        co2
+      }
+      chargeTime
+      distance
+      duration
+      consumption
+      elevationPlot
+      elevationUp
+      elevationDown
+      id
+      polyline
+      legs{
+        distance
+        chargeTime
+        origin{
+          geometry{
+            type
+            coordinates
+          }
+        }
+        destination{
+          geometry
+          {
+            type
+            coordinates
+          }
+        }
+      }
+    }
+    status
+  }
+}`;
+
 export const routeUpdate = qql`
 subscription routeUpdatedById($id: ID!){
   routeUpdatedById(id: $id) {

--- a/elevation-plot/client.js
+++ b/elevation-plot/client.js
@@ -58,7 +58,7 @@ export const fetchRoute = callback => {
           // For this example we want to only draw the initial route.
           if (status === 'done' && route) {
             unsubscribe();
-            callback(routeId, result.data?.routeUpdatedById?.route);
+            callback(routeId, route);
           }
         }),
       );
@@ -73,7 +73,7 @@ export const fetchRoute = callback => {
           const { status, route } = response.data.route;
           if (status === 'done' && route) {
             unsubscribe();
-            callback(routeId, response.data?.routeUpdatedById?.route);
+            callback(routeId, route);
           }
         });
     })

--- a/elevation-plot/queries.js
+++ b/elevation-plot/queries.js
@@ -83,6 +83,39 @@ subscription routeUpdatedById($id: ID!){
 }
 `;
 
+export const queryRoute = qql`
+query getRoute($id: ID!) {
+  route(id: $id) {
+    status
+    route {
+      distance
+      duration
+      elevationPlot
+      elevationUp
+      elevationDown
+      id
+      polyline
+      legs{
+        distance
+        chargeTime
+        origin{
+          geometry{
+            type
+            coordinates
+          }
+        }
+        destination{
+          geometry
+          {
+            type
+            coordinates
+          }
+        }
+      }
+    }
+  }
+}`;
+
 export const getRoutePath = (id, location) => `
 {
     routePath(

--- a/route/index.js
+++ b/route/index.js
@@ -1,7 +1,7 @@
 import { createClient, createRequest, defaultExchanges, subscriptionExchange } from '@urql/core';
 import { pipe, subscribe } from 'wonka';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
-import { createRoute, routeUpdate } from './queries.js';
+import { createRoute, routeUpdate, queryRoute } from './queries.js';
 import { drawRoute } from './map.js';
 import * as mapboxPolyline from '@mapbox/polyline';
 import { getDurationString } from '../utils';
@@ -69,6 +69,22 @@ client
         }
       }),
     );
+
+    // Query for the route once to check if the route is computed before the subscription was setup.
+    // In this case we use the response from the query and unsubscribe from the route.
+    // For more informations about routes: https://docs.chargetrip.com/#routes
+    client
+      .query(queryRoute, { id: routeId })
+      .toPromise()
+      .then(response => {
+        const { status, route } = response.data.route;
+        if (status === 'done' && route) {
+          console.log({ route });
+          unsubscribe();
+          drawRoutePolyline(route);
+          displayRouteData(route);
+        }
+      });
   })
   .catch(error => console.log(error));
 

--- a/route/index.js
+++ b/route/index.js
@@ -63,7 +63,6 @@ client
         // for this example we want to only draw the initial route
         if (status === 'done' && route) {
           unsubscribe();
-
           drawRoutePolyline(route); // draw a polyline on a map
           displayRouteData(route); // fill in the route information
         }
@@ -79,7 +78,6 @@ client
       .then(response => {
         const { status, route } = response.data.route;
         if (status === 'done' && route) {
-          console.log({ route });
           unsubscribe();
           drawRoutePolyline(route);
           displayRouteData(route);

--- a/route/queries.js
+++ b/route/queries.js
@@ -49,6 +49,46 @@ mutation newRoute{
   }
 `;
 
+export const queryRoute = qql`
+query getRoute($id: ID!) {
+  route(id: $id) {
+    route {
+      charges
+      saving {
+        money
+        co2
+      }
+      chargeTime
+      distance
+      duration
+      consumption
+      elevationPlot
+      elevationUp
+      elevationDown
+      id
+      polyline
+      legs{
+        distance
+        chargeTime
+        origin{
+          geometry{
+            type
+            coordinates
+          }
+        }
+        destination{
+          geometry
+          {
+            type
+            coordinates
+          }
+        }
+      }
+    }
+    status
+  }
+}`;
+
 export const routeUpdate = qql`
 subscription routeUpdatedById($id: ID!){
   routeUpdatedById(id: $id) {

--- a/state-of-charge/client.js
+++ b/state-of-charge/client.js
@@ -1,6 +1,6 @@
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 import { createClient, createRequest, defaultExchanges, subscriptionExchange } from '@urql/core';
-import { createRoute, getRoutePath, routeUpdate } from './queries';
+import { createRoute, routeUpdate, queryRoute } from './queries';
 import { pipe, subscribe } from 'wonka';
 
 /**
@@ -63,6 +63,20 @@ export const fetchRoute = (soc, callback) => {
           }
         }),
       );
+
+      // Query for the route once to check if the route is computed before the subscription was setup.
+      // In this case we use the response from the query and unsubscribe from the route.
+      // For more informations about routes: https://docs.chargetrip.com/#routes
+      client
+        .query(queryRoute, { id: routeId })
+        .toPromise()
+        .then(result => {
+          const { status, route } = response.data.route;
+          if (status === 'done' && route) {
+            unsubscribe();
+            callback(routeId, result.data?.routeUpdatedById?.route);
+          }
+        });
     })
     .catch(error => console.log(error));
 };

--- a/state-of-charge/client.js
+++ b/state-of-charge/client.js
@@ -53,13 +53,12 @@ export const fetchRoute = (soc, callback) => {
         client.executeSubscription(createRequest(routeUpdate, { id: routeId })),
         subscribe(result => {
           const { status, route } = result.data?.routeUpdatedById;
-
           // You can keep listening to the route changes to update route information.
           // For this example we want to only draw the initial route.
           if (status === 'done' && route) {
             document.getElementById('calculating').style.display = 'none';
             unsubscribe();
-            callback(result.data?.routeUpdatedById?.route);
+            callback(route);
           }
         }),
       );
@@ -71,10 +70,10 @@ export const fetchRoute = (soc, callback) => {
         .query(queryRoute, { id: routeId })
         .toPromise()
         .then(result => {
-          const { status, route } = response.data.route;
+          const { status, route } = result.data.route;
           if (status === 'done' && route) {
             unsubscribe();
-            callback(routeId, result.data?.routeUpdatedById?.route);
+            callback(routeId, route);
           }
         });
     })

--- a/state-of-charge/queries.js
+++ b/state-of-charge/queries.js
@@ -46,6 +46,34 @@ mutation newRoute{
   }
 `;
 
+export const queryRoute = qql`
+query getRoute($id: ID!) {
+  route(id: $id) {
+    status
+    route {
+      duration
+      polyline
+      legs{
+        rangeEnd
+        rangeStart
+        origin{
+          geometry{
+            type
+            coordinates
+          }
+        }
+        destination{
+          geometry
+          {
+            type
+            coordinates
+          }
+        }
+      }
+    }
+  }
+}`;
+
 export const routeUpdate = qql`
 subscription routeUpdatedById($id: ID!){
   routeUpdatedById(id: $id) {


### PR DESCRIPTION
Do a query right after setting up the subscription. If the route was computed before the subscription was successfully setup, we use the response of the query. 

Should also be implemented for the other examples