### PR TITLE
feat: alternative routes added

### DIFF
--- a/public/route/index.html
+++ b/public/route/index.html
@@ -24,7 +24,7 @@
     <div class="journey-specs">
       <header>
         <span class="duration" id="duration"></span>
-        <h1>Amsterdam • Berlin</h1>
+        <h1>Amsterdam • Neubrandenburg</h1>
         <span id="loader">Loading...</span>
         <div class="tags">
           <div id="distance" class="tag"></div>

--- a/route/README.md
+++ b/route/README.md
@@ -2,7 +2,7 @@
 
 This tutorial covers the basics of building a simple route between an origin and a destination:
 
-1.  show a route on a map;
+1.  show a route and route alternatives on a map;
 2.  show charging stations and charging time information;
 3.  show information about the whole journey duration;
 4.  show information about energy consumption.
@@ -22,7 +22,7 @@ We use our Playground environment for this example. It means that only part of o
 
 To build a route, you will need a car (the associated consumption model of a vehicle will be applied to the routing algorithm), station database, origin, and a destination.
 
-For this example, we use **Tesla model S**, **Amsterdam** as an origin, and **Berlin** as a destination point.
+For this example, we use **Tesla model S**, **Amsterdam** as an origin, and **Neubrandenburg** as a destination point.
 Chargetrip operates an extensive database of EVs, each with their specific consumption models. You can find more information about our database and available queries by checking [Chargetrip API documentation](https://docs.chargetrip.com/#cars).
 
 Our Playground has a station database that is populated with freely available European station data from [OCM](https://openchargemap.org/site). Importing your own database or using one of the databases Chargetrip has an integration with, is possible. For more details, contact us.
@@ -33,9 +33,9 @@ Once we have a car and station database, we can start planning the route:
 
 1. We have to request a new route. For that we use the `newRoute` mutation. We will need to pass information about the car, origin and destination. As a result we will get an ID of a newly created route. You can read all the details about this mutation in our [Chargetrip API documentation](https://docs.chargetrip.com/#request-a-new-route).
 2. With a route ID we can request route information. We will subscribe to a route update to receive dynamic updates for it (recommended route, alternative routes (if available), time duration, consumption etc). You can read all the details about this subscription in our [Graph API documentation](https://docs.chargetrip.com/#subscribe-to-route-updates).
-3. Having the route details we can show a route on a map. To show stations, where a car must stop for charging, we use route `legs` object, where each leg is a station.
+3. Having the route details we can show a route and the alternatives on a map. To show stations, where a car must stop for charging, we use route `legs` object, where each leg is a station.
 4. We can also query route details for information like total distance, duration of a trip, consumption etc. You can see all available fields to query in the [Chargetrip API documentation](https://docs.chargetrip.com/#get-route-details).
-5. The final step is to show the route on a map. We use [MapboxGL JS](https://docs.mapbox.com/mapbox-gl-js/overview/#quickstart) in this example.
+5. The final step is to show the route and alternative routes on a map. We use [MapboxGL JS](https://docs.mapbox.com/mapbox-gl-js/overview/#quickstart) in this example.
 
 ### Useful links
 

--- a/route/queries.js
+++ b/route/queries.js
@@ -57,6 +57,7 @@ query getRoute($id: ID!) {
       polyline
       charges
       duration
+      distance
       consumption
       chargeTime
       saving {
@@ -127,6 +128,7 @@ subscription routeUpdatedById($id: ID!){
       polyline
       charges
       duration
+      distance
       consumption
       chargeTime
       saving {

--- a/route/queries.js
+++ b/route/queries.js
@@ -40,8 +40,8 @@ mutation newRoute{
           }
           destination: {
             type: Feature
-            geometry: { type: Point, coordinates: [13.3888599, 52.5170365] }
-            properties: { name: "Berlin, Germany" }
+            geometry: { type: Point, coordinates: [13.2779, 53.5678] }
+            properties: { name: "neubrandenburg, Germany" }
           }
         }
       }
@@ -52,6 +52,35 @@ mutation newRoute{
 export const queryRoute = qql`
 query getRoute($id: ID!) {
   route(id: $id) {
+    alternatives {
+      id
+      polyline
+      charges
+      duration
+      consumption
+      chargeTime
+      saving {
+        money
+        co2
+      }
+      legs{
+        distance
+        chargeTime
+        origin{
+          geometry{
+            type
+            coordinates
+          }
+        }
+        destination{
+          geometry
+          {
+            type
+            coordinates
+          }
+        }
+      }
+    }
     route {
       charges
       saving {
@@ -93,6 +122,35 @@ export const routeUpdate = qql`
 subscription routeUpdatedById($id: ID!){
   routeUpdatedById(id: $id) {
     status
+    alternatives {
+      id
+      polyline
+      charges
+      duration
+      consumption
+      chargeTime
+      saving {
+        money
+        co2
+      }
+      legs{
+        distance
+        chargeTime
+        origin{
+          geometry{
+            type
+            coordinates
+          }
+        }
+        destination{
+          geometry
+          {
+            type
+            coordinates
+          }
+        }
+      }
+    }
     route {
       charges
       saving {


### PR DESCRIPTION
Alternative routes are now available. I have added them to the route example. The destination has changed because this destination gives 3 very different routes. The alternative routes are clickable, on click the selected route will show the charging stations and will update the journey specs. 