### PR TITLE
fix: remove final state of charge

### DIFF
--- a/elevation-plot/queries.js
+++ b/elevation-plot/queries.js
@@ -2,12 +2,12 @@ import qql from 'graphql-tag';
 
 /*
  * In this example we request a route from Amsterdam, Netherlands to Berlin, Germany
+ * Your origin and destination are required fields. You also need to select an EV.
+ * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The changing conditions are:
  *   - full battery at Amsterdam, Netherlands
- *   - no desired range at Berlin, Germany
- *   - EV can charge at CHadMO changers
+ *   - EV can charge at CHAdeMO changers
  *   - should use climate (temperature and weather conditions)
- *   - the EV driver can drive 40 km less than the EV specs (specs is 440 km, custom range is 400 km)
  *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  */
@@ -27,7 +27,6 @@ mutation newRoute{
             { chargingPower: 150, standard: CHADEMO }
           ]
           climate: true
-          minPower: 43
           numberOfPassengers: 1
         }
         routeRequest: {

--- a/elevation-plot/queries.js
+++ b/elevation-plot/queries.js
@@ -7,8 +7,8 @@ import qql from 'graphql-tag';
  *   - no desired range at Berlin, Germany
  *   - EV can charge at CHadMO changers
  *   - should use climate (temperature and weather conditions)
- *   - the EV driver can drive 40 km  less than the EV specs (specs is 440 km, custom range is 400 km)
- *   - min power of chargers is 43 kWh
+ *   - the EV driver can drive 40 km less than the EV specs (specs is 440 km, custom range is 400 km)
+ *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  */
 export const createRoute = qql`
@@ -20,7 +20,6 @@ mutation newRoute{
           battery: {
             capacity: { value: 72.5, type: kwh }
             stateOfCharge: { value: 72.5, type: kwh }
-            finalStateOfCharge: { value: 0, type: kwh }
           }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [

--- a/route/queries.js
+++ b/route/queries.js
@@ -8,7 +8,7 @@ import qql from 'graphql-tag';
  *   - EV can charge at CHadMO changers
  *   - should use climate (temperature and weather conditions)
  *   - the EV driver can drive 40 km  less than the EV specs (specs is 440 km, custom range is 400 km)
- *   - min power of chargers is 43 kWh
+ *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  */
 export const createRoute = qql`
@@ -20,7 +20,6 @@ mutation newRoute{
           battery: {
             capacity: { value: 72.5, type: kwh }
             stateOfCharge: { value: 72.5, type: kwh }
-            finalStateOfCharge: { value: 0, type: kwh }
           }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [

--- a/route/queries.js
+++ b/route/queries.js
@@ -2,6 +2,8 @@ import qql from 'graphql-tag';
 
 /*
  * In this example we request a route from Amsterdam, Netherlands to Berlin, Germany
+ * Your origin and destination are required fields. You also need to select an EV.
+ * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The changing conditions are:
  *   - full battery at Amsterdam, Netherlands
  *   - no desired range at Berlin, Germany

--- a/route/queries.js
+++ b/route/queries.js
@@ -6,10 +6,8 @@ import qql from 'graphql-tag';
  * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The changing conditions are:
  *   - full battery at Amsterdam, Netherlands
- *   - no desired range at Berlin, Germany
- *   - EV can charge at CHadMO changers
+ *   - EV can charge at CHAdeMO changers
  *   - should use climate (temperature and weather conditions)
- *   - the EV driver can drive 40 km  less than the EV specs (specs is 440 km, custom range is 400 km)
  *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  */
@@ -29,7 +27,6 @@ mutation newRoute{
             { chargingPower: 150, standard: CHADEMO }
           ]
           climate: true
-          minPower: 43
           numberOfPassengers: 1
         }
         routeRequest: {

--- a/state-of-charge/queries.js
+++ b/state-of-charge/queries.js
@@ -7,7 +7,7 @@ import qql from 'graphql-tag';
  *   - no desired range at Berlin, Germany
  *   - EV can charge at CHadMO changers
  *   - should use climate (temperature and weather conditions)
- *   - min power of chargers is 43 kWh
+ *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  */
 export const createRoute = soc => `
@@ -19,7 +19,6 @@ mutation newRoute{
           battery: {
             capacity: { value: 72.5, type: kwh }
             stateOfCharge: { value: ${soc}, type: km }
-            finalStateOfCharge: { value: 0, type: kwh }
           }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [

--- a/state-of-charge/queries.js
+++ b/state-of-charge/queries.js
@@ -2,9 +2,10 @@ import qql from 'graphql-tag';
 
 /*
  * In this example we request a route from Amsterdam, Netherlands to Berlin, Germany
+ * Your origin and destination are required fields. You also need to select an EV.
+ * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The conditions are:
  *   - full battery at Amsterdam, Germany
- *   - no desired range at Berlin, Germany
  *   - EV can charge at CHadMO changers
  *   - should use climate (temperature and weather conditions)
  *   - min power of chargers is 43 kWh. This is the default setting

--- a/state-of-charge/queries.js
+++ b/state-of-charge/queries.js
@@ -6,7 +6,7 @@ import qql from 'graphql-tag';
  * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The conditions are:
  *   - full battery at Amsterdam, Germany
- *   - EV can charge at CHadMO changers
+ *   - EV can charge at CHAdeMO changers
  *   - should use climate (temperature and weather conditions)
  *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
@@ -27,7 +27,6 @@ mutation newRoute{
             { chargingPower: 150, standard: CHADEMO }
           ]
           climate: true
-          minPower: 43
           numberOfPassengers: 1
         }
         routeRequest: {

--- a/stations-along-route/queries.js
+++ b/stations-along-route/queries.js
@@ -6,7 +6,6 @@ import qql from 'graphql-tag';
  * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The changing conditions are:
  *   - full battery at Amsterdam, Netherlands
- *   - no desired range at Utrecht, Netherlands
  *   - EV can charge at CHadMO changers
  *   - should use climate (temperature and weather conditions)
  *   - the EV driver can drive 40 km  less than the EV specs (specs is 440 km, custom range is 400 km)

--- a/stations-along-route/queries.js
+++ b/stations-along-route/queries.js
@@ -6,10 +6,8 @@ import qql from 'graphql-tag';
  * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The changing conditions are:
  *   - full battery at Amsterdam, Netherlands
- *   - EV can charge at CHadMO changers
+ *   - EV can charge at CHAdeMO changers
  *   - should use climate (temperature and weather conditions)
- *   - the EV driver can drive 40 km  less than the EV specs (specs is 440 km, custom range is 400 km)
- *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  *   - stations along the route radius is 2km
  */
@@ -29,7 +27,6 @@ mutation newRoute{
             { chargingPower: 150, standard: CHADEMO }
           ]
           climate: true
-          minPower: 43
           numberOfPassengers: 1
         }
         routeRequest: {

--- a/stations-along-route/queries.js
+++ b/stations-along-route/queries.js
@@ -2,6 +2,8 @@ import qql from 'graphql-tag';
 
 /*
  * In this example we request a route from Amsterdam, Netherlands to Utrecht, Netherlands
+ * Your origin and destination are required fields. You also need to select an EV.
+ * Only the EV ID here is mandatory, all other fields are optional and when not specified will use the default values.
  * The changing conditions are:
  *   - full battery at Amsterdam, Netherlands
  *   - no desired range at Utrecht, Netherlands

--- a/stations-along-route/queries.js
+++ b/stations-along-route/queries.js
@@ -8,7 +8,7 @@ import qql from 'graphql-tag';
  *   - EV can charge at CHadMO changers
  *   - should use climate (temperature and weather conditions)
  *   - the EV driver can drive 40 km  less than the EV specs (specs is 440 km, custom range is 400 km)
- *   - min power of chargers is 43 kWh
+ *   - min power of chargers is 43 kWh. This is the default setting
  *   - one passenger in the car (drive alone)
  *   - stations along the route radius is 2km
  */
@@ -21,7 +21,6 @@ mutation newRoute{
           battery: {
             capacity: { value: 72.5, type: kwh }
             stateOfCharge: { value: 50.5, type: kwh }
-            finalStateOfCharge: { value: 0, type: kwh }
           }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [


### PR DESCRIPTION
The final state of charge was set to 0. Event hough we do allow this I removed it as it might cause confusion. I also explicitly mentioned what fields are mandatory and what fields are not. 