### PR TITLE
fix: fixed radius as it can not be bigger than 10 000

### DIFF
--- a/station-info/client.js
+++ b/station-info/client.js
@@ -30,7 +30,7 @@ export const fetchStations = () =>
     .query(getStationsAround, {
       query: {
         location: { type: 'Point', coordinates: [9.9801115, 53.5475679] },
-        distance: 300000,
+        distance: 3000,
       },
     })
     .toPromise()


### PR DESCRIPTION
I fixed the radius for "stationsAround" query. I think I meant to use 3000, but added an additional 0 and somehow it was working before the last releases ;)  