### PR TITLE
fix: cleanup queries

### DIFF
--- a/alternative-routes/queries.js
+++ b/alternative-routes/queries.js
@@ -14,9 +14,6 @@ mutation newRoute{
       input: {
         ev: {
           id: "5d161be5c9eef46132d9d20a"
-          battery: {
-            stateOfCharge: { value: 72.5, type: kwh }
-          }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [
             { chargingPower: 150, standard: IEC_62196_T2_COMBO }
@@ -47,7 +44,6 @@ export const queryRoute = qql`
 query getRoute($id: ID!) {
   route(id: $id) {
     alternatives {
-      type
       polyline
       charges
       duration
@@ -86,10 +82,6 @@ query getRoute($id: ID!) {
       distance
       duration
       consumption
-      elevationPlot
-      elevationUp
-      elevationDown
-      type
       polyline
       legs{
         distance
@@ -157,10 +149,6 @@ subscription routeUpdatedById($id: ID!){
       distance
       duration
       consumption
-      elevationPlot
-      elevationUp
-      elevationDown
-      type
       polyline
       legs{
         distance

--- a/elevation-plot/queries.js
+++ b/elevation-plot/queries.js
@@ -17,10 +17,6 @@ mutation newRoute{
       input: {
         ev: {
           id: "5d161be5c9eef46132d9d20a"
-          battery: {
-            capacity: { value: 72.5, type: kwh }
-            stateOfCharge: { value: 72.5, type: kwh }
-          }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [
             { chargingPower: 150, standard: IEC_62196_T2_COMBO }
@@ -53,15 +49,12 @@ subscription routeUpdatedById($id: ID!){
     status
     route {
       distance
-      duration
       elevationPlot
       elevationUp
       elevationDown
-      id
       polyline
       legs{
         distance
-        chargeTime
         origin{
           geometry{
             type
@@ -87,7 +80,6 @@ query getRoute($id: ID!) {
     status
     route {
       distance
-      duration
       elevationPlot
       elevationUp
       elevationDown
@@ -95,7 +87,6 @@ query getRoute($id: ID!) {
       polyline
       legs{
         distance
-        chargeTime
         origin{
           geometry{
             type

--- a/public/route/style.css
+++ b/public/route/style.css
@@ -219,7 +219,7 @@ section:last-child {
 .mapboxgl-popup-content {
   width: 50px;
   padding: 1px;
-  margin-bottom: 30px;
+  margin-bottom: 40px;
   background: #030303;
   color: #ffffff;
   text-align: center;

--- a/public/state-of-charge/style.css
+++ b/public/state-of-charge/style.css
@@ -337,7 +337,7 @@ input[type='range']::-moz-range-thumb {
 .mapboxgl-popup-content {
   width: 120px;
   padding: 10px;
-  margin-bottom: 30px;
+  margin-bottom: 40px;
   background: #030303;
   color: #ffffff;
   text-align: center;

--- a/route/queries.js
+++ b/route/queries.js
@@ -17,10 +17,6 @@ mutation newRoute{
       input: {
         ev: {
           id: "5d161be5c9eef46132d9d20a"
-          battery: {
-            capacity: { value: 72.5, type: kwh }
-            stateOfCharge: { value: 72.5, type: kwh }
-          }
           plugs: { chargingPower: 150, standard: TESLA_S }
           adapters: [
             { chargingPower: 150, standard: IEC_62196_T2_COMBO }
@@ -60,13 +56,8 @@ query getRoute($id: ID!) {
       distance
       duration
       consumption
-      elevationPlot
-      elevationUp
-      elevationDown
-      id
       polyline
       legs{
-        distance
         chargeTime
         origin{
           geometry{
@@ -101,13 +92,8 @@ subscription routeUpdatedById($id: ID!){
       distance
       duration
       consumption
-      elevationPlot
-      elevationUp
-      elevationDown
-      id
       polyline
       legs{
-        distance
         chargeTime
         origin{
           geometry{

--- a/state-of-charge/queries.js
+++ b/state-of-charge/queries.js
@@ -18,7 +18,6 @@ mutation newRoute{
         ev: {
           id: "5d161be5c9eef46132d9d20a"
           battery: {
-            capacity: { value: 72.5, type: kwh }
             stateOfCharge: { value: ${soc}, type: km }
           }
           plugs: { chargingPower: 150, standard: TESLA_S }

--- a/stations-along-route/queries.js
+++ b/stations-along-route/queries.js
@@ -58,7 +58,6 @@ subscription routeUpdatedById($id: ID!){
       polyline
       legs{
         distance
-        chargeTime
         origin{
           geometry{
             type

--- a/stations/queries.js
+++ b/stations/queries.js
@@ -10,17 +10,11 @@ query stationAround($query: StationAroundQuery!){
   stationAround(
       query: $query
       size: 20
-      page: 0
     ) {
-      id
-      external_id
-      address
       location {
         type
         coordinates
       }
-      elevation
-      amenities
       power
       speed
       status


### PR DESCRIPTION
I have removed fields from the query that we are not using for that example. I have also adjusted the margins of some of the pop-ups as we before made the station icons bigger. Now the popups and icons are no longer overlapping. 