### PR TITLE
fix: jump in city names

### DIFF
--- a/alternative-routes/map.js
+++ b/alternative-routes/map.js
@@ -167,6 +167,7 @@ const showLegs = legs => {
     layout: {
       'icon-image': '{icon}',
       'icon-allow-overlap': true,
+      'icon-ignore-placement': true,
       'icon-size': ['case', ['==', ['get', 'icon'], 'location-big'], ['literal', 0.7], ['literal', 0.8]],
       'icon-offset': ['case', ['==', ['get', 'icon'], 'location_big'], ['literal', [0, 0]], ['literal', [0, -15]]],
     },

--- a/stations-along-route/map.js
+++ b/stations-along-route/map.js
@@ -121,6 +121,7 @@ const showLegs = legs => {
     layout: {
       'icon-image': '{icon}',
       'icon-allow-overlap': true,
+      'icon-ignore-placement': true,
       'icon-offset': ['case', ['==', ['get', 'icon'], 'location_big'], ['literal', [0, 0]], ['literal', [0, -15]]],
     },
     source: {


### PR DESCRIPTION
The city names sometimes jumped because icons were sometimes covering them and sometimes not. Therefore they are now allowed to cover the city names. 