### PR TITLE
fix: add comments about the x-client-id

### DIFF
--- a/alternative-routes/index.js
+++ b/alternative-routes/index.js
@@ -17,6 +17,7 @@ import { getDurationString } from '../utils';
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/car-list/index.js
+++ b/car-list/index.js
@@ -21,6 +21,7 @@ new mapboxgl.Map({
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more cars
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/car/client.js
+++ b/car/client.js
@@ -10,6 +10,7 @@ import { renderCarList } from './cars';
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more cars
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/elevation-plot/client.js
+++ b/elevation-plot/client.js
@@ -11,6 +11,7 @@ import { pipe, subscribe } from 'wonka';
  * Read more about authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/route/index.js
+++ b/route/index.js
@@ -17,6 +17,7 @@ import { getDurationString } from '../utils';
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/state-of-charge/client.js
+++ b/state-of-charge/client.js
@@ -11,6 +11,7 @@ import { pipe, subscribe } from 'wonka';
  * Read more about authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/station-info/client.js
+++ b/station-info/client.js
@@ -9,6 +9,7 @@ import { getStationData, getStationsAround } from './queries';
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/stations-along-route/index.js
+++ b/stations-along-route/index.js
@@ -18,6 +18,7 @@ import { getDurationString } from '../utils';
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/stations/index.js
+++ b/stations/index.js
@@ -11,6 +11,7 @@ import { initFilters } from './filters.js';
  * Read more about an authorisation in our documentation (https://docs.chargetrip.com/#authorisation).
  */
 const headers = {
+  //Replace this x-client-id with your own to get access to more station data
   'x-client-id': '5ed1175bad06853b3aa1e492',
 };
 

--- a/tile-server/map.js
+++ b/tile-server/map.js
@@ -22,6 +22,7 @@ export const displayMap = () => {
     transformRequest: (url, resourceType) => {
       if (resourceType === 'Tile' && url.startsWith('https://api.chargetrip.io')) {
         const headers = {
+          //Replace this x-client-id with your own to get access to more station data
           'x-client-id': '5ed1175bad06853b3aa1e492',
           'Cache-Control': 'max-age=0',
         };


### PR DESCRIPTION
Before the x-client-id is set there is already a comment explaining that the x-client-id only gives access to part of the database. I have added one extra comment to make it clear that they can replace it with their own. 