### PR TITLE
fix: remove hardcoded initial number

### DIFF
--- a/public/stations/index.html
+++ b/public/stations/index.html
@@ -22,7 +22,7 @@
     <div id="map"></div>
     <div class="card">
       <header>
-        <h1 id="stationAmount">13 stations</h1>
+        <h1 id="stationAmount">- stations</h1>
         <p>Limited to 20 stations</p>
       </header>
       <main>

--- a/station-info/queries.js
+++ b/station-info/queries.js
@@ -1,8 +1,7 @@
 import qql from 'graphql-tag';
 
 /**
- * For this query we are requesting the 20 closest stations.
- * The default for this query is 10.
+ * For this query we are requesting data about a specific station
  */
 export const getStationData = qql`
 query station($stationId: ID!){


### PR DESCRIPTION
We hard-coded the initial amount of stations. There are now more stations there than before so the number jumped from 13 to 20. 