### PR TITLE
Fix/stations bug

### DIFF
--- a/public/stations/index.html
+++ b/public/stations/index.html
@@ -22,7 +22,7 @@
     <div id="map"></div>
     <div class="card">
       <header>
-        <h1 id="stationAmount">13 stations</h1>
+        <h1 id="stationAmount">- stations</h1>
         <p>Limited to 20 stations</p>
       </header>
       <main>

--- a/station-info/map.js
+++ b/station-info/map.js
@@ -65,6 +65,7 @@ export const showStations = stations => {
       'icon-image': '{icon}',
       'icon-allow-overlap': true,
       'icon-size': 0.9,
+      'icon-offset': [0, -16],
     },
     source: {
       type: 'geojson',

--- a/station-info/queries.js
+++ b/station-info/queries.js
@@ -1,8 +1,7 @@
 import qql from 'graphql-tag';
 
 /**
- * For this query we are requesting the 20 closest stations.
- * The default for this query is 10.
+ * For this query we are requesting data about a specific station
  */
 export const getStationData = qql`
 query station($stationId: ID!){

--- a/stations/map.js
+++ b/stations/map.js
@@ -76,6 +76,7 @@ export const showStations = stations => {
       'icon-image': '{icon}',
       'icon-allow-overlap': true,
       'icon-size': 0.9,
+      'icon-offset': [0, -16],
     },
     source: {
       type: 'geojson',


### PR DESCRIPTION
Because there was no offset before stations kept changing position. Before zooming in they might have been one side of the road and after on the other. The offset makes it so that the bottom of the icon is always on the coornates. 