### PR TITLE
fix(isoline): prevent websocket reconnect

### DIFF
--- a/examples/5.isolines/1.isoline/client.js
+++ b/examples/5.isolines/1.isoline/client.js
@@ -18,7 +18,6 @@ const headers = {
 
 const subscriptionClient = new SubscriptionClient('wss://api.chargetrip.io/graphql', {
   reconnect: true,
-  timeout: 4000,
   connectionParams: headers,
 });
 


### PR DESCRIPTION
This pull requests prevents opening and closing a new connection every `4000 ms` to check whether the isoline has completed calculation, since the subscription will now do so.